### PR TITLE
use sudo in getFootprint ssh

### DIFF
--- a/jmeter-scripts/getFootprint.sh
+++ b/jmeter-scripts/getFootprint.sh
@@ -1,7 +1,7 @@
 IP=${1}
 
 PID=$(ssh ${IP} ps -ef | grep java | grep -v grep | awk '{print $2}' | tail -1)
-FP=$(ssh ${IP} cat /proc/${PID}/smaps | grep 'Rss' | awk '{total+=$2;} END{print total;}' | numfmt --from-unit=1024 --to=iec | awk '{gsub("M"," "); print $1}')
+FP=$(ssh ${IP} sudo cat /proc/${PID}/smaps | grep 'Rss' | awk '{total+=$2;} END{print total;}' | numfmt --from-unit=1024 --to=iec | awk '{gsub("M"," "); print $1}')
 echo
 echo "Footprint: $FP"
 echo


### PR DESCRIPTION
a similar change was made to pingPerf to account for the SUT requiring root permission but the load driver runs with a different user